### PR TITLE
Allow package to be used in laravel 9.x and 10.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.2|^7.3|^8.0|^8.1",
-        "illuminate/support": "~6|~7|~8",
+        "illuminate/support": "~6|~7|~8|~9|~10",
         "guzzlehttp/guzzle": "^7.0.1"
     },
     "extra": {

--- a/src/Apis/BaseApi.php
+++ b/src/Apis/BaseApi.php
@@ -183,7 +183,7 @@ class BaseApi
         }
 
         foreach ($requiredFields as $filed) {
-            if (isset($data[$filed]) && empty($data[$filed])) {
+            if (isset($data[$filed]) && $data[$filed] == "") {
                 throw new PathaoCourierValidationException("$filed is required", 422);
             }
         }


### PR DESCRIPTION
As this package supports php 8.0 and 8.1 and it doesn't have any conflicting package,

It can be used in laravel 9.x and 10.x too

Fixes #3 