### PR TITLE
Use blank string check instead of empty function

### DIFF
--- a/src/Apis/BaseApi.php
+++ b/src/Apis/BaseApi.php
@@ -183,7 +183,7 @@ class BaseApi
         }
 
         foreach ($requiredFields as $filed) {
-            if (isset($data[$filed]) && empty($data[$filed])) {
+            if (isset($data[$filed]) && $data[$filed] == "") {
                 throw new PathaoCourierValidationException("$filed is required", 422);
             }
         }


### PR DESCRIPTION
As empty function returns false on 0 or '0', it is not expected to fail validation on 0 value.

Fixes #5 