### PR TITLE
Change Default Bearer Token store path and add new endpoint for success rate

### DIFF
--- a/config/pathao.php
+++ b/config/pathao.php
@@ -5,5 +5,6 @@ return [
     "client_id"     => env("PATHAO_CLIENT_ID", ""),
     "client_secret" => env("PATHAO_CLIENT_SECRET", ""),
     "username"      => env("PATHAO_USERNAME", ""),
-    "password"      => env("PATHAO_PASSWORD", "")
+    "password"      => env("PATHAO_PASSWORD", ""),
+    "disk"          => env("PATHAO_DISK", "local")
 ];

--- a/src/Apis/OrderApi.php
+++ b/src/Apis/OrderApi.php
@@ -74,4 +74,37 @@ class OrderApi extends BaseApi
         $response = $this->authorization()->send("POST", "aladdin/api/v1/merchant/price-plan", $array);
         return $response->data;
     }
+
+
+    /**
+     * Order Cancel
+     *
+     * @param string $consignmentId
+     *
+     * @return mixed
+     * @throws GuzzleException
+     * @throws PathaoException
+     */
+
+     public function cancel($consignmentId)
+     {
+         $response = $this->authorization()->send("POST", "aladdin/api/v1/orders/{$consignmentId}/cancel");
+         return $response->data;
+     }
+ 
+     /**
+      * Get customer success rate
+      *
+      * @param string $phone
+      *
+      * @return mixed
+      * @throws GuzzleException
+      * @throws PathaoException
+      */
+ 
+     public function successRate($phone)
+     {
+         $response = $this->authorization()->send("POST", "aladdin/api/v1/user/success", ['phone' => $phone]);
+         return $response->data;
+     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `pathao` configuration and API methods to improve flexibility and functionality. The most important changes include adding a new configuration option, modifying method access levels, and adding new API methods.

Configuration updates:
* [`config/pathao.php`](diffhunk://#diff-963b2ec635b30e51faad1b28755971bedee0297cfbcbfcdd780ad0d07a18deefL8-R9): Added a new configuration option `disk` to specify the storage disk.

Method access level changes:
* [`src/Apis/BaseApi.php`](diffhunk://#diff-bdd1f7d2621ee72f0a84f3778e5a5805cfa1506e4a5a67a25eaaf7e7dd48649eL42-R42): Changed the access level of the `setBaseUrl`, `setHeaders`, `mergeHeader`, and `authenticate` methods from private to public. [[1]](diffhunk://#diff-bdd1f7d2621ee72f0a84f3778e5a5805cfa1506e4a5a67a25eaaf7e7dd48649eL42-R42) [[2]](diffhunk://#diff-bdd1f7d2621ee72f0a84f3778e5a5805cfa1506e4a5a67a25eaaf7e7dd48649eL54-R54) [[3]](diffhunk://#diff-bdd1f7d2621ee72f0a84f3778e5a5805cfa1506e4a5a67a25eaaf7e7dd48649eL67-R67) [[4]](diffhunk://#diff-bdd1f7d2621ee72f0a84f3778e5a5805cfa1506e4a5a67a25eaaf7e7dd48649eL77-R77)
* [`src/Apis/BaseApi.php`](diffhunk://#diff-bdd1f7d2621ee72f0a84f3778e5a5805cfa1506e4a5a67a25eaaf7e7dd48649eL93-R93): Updated the `authenticate` method to use the configured storage disk. [[1]](diffhunk://#diff-bdd1f7d2621ee72f0a84f3778e5a5805cfa1506e4a5a67a25eaaf7e7dd48649eL93-R93) [[2]](diffhunk://#diff-bdd1f7d2621ee72f0a84f3778e5a5805cfa1506e4a5a67a25eaaf7e7dd48649eL108-R119)

New API methods:
* [`src/Apis/OrderApi.php`](diffhunk://#diff-eec36b1a47883fb3c5b7c7eba31b473a18708f5e42e772683305ec94fda7b1d0R77-R109): Added `cancel` and `successRate` methods to handle order cancellations and retrieve customer success rates.